### PR TITLE
Django 1.4 compatibility and packaging fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include django_js_utils/static/dutils.js

--- a/django_js_utils/management/commands/js_urls.py
+++ b/django_js_utils/management/commands/js_urls.py
@@ -64,6 +64,8 @@ class Command(BaseCommand):
                     if args_matches:
                         for el in args_matches:
                             full_url = full_url.replace(el, "<>")#replace by a empty parameter name
+                    #unescape escaped chars which are not special sequences
+                    full_url = re.sub(r'\\([^\dAZbBdDsSwW])', r'\1', full_url)
                     js_patterns[pattern.name] = "/" + full_url
             elif issubclass(pattern.__class__, RegexURLResolver):
                 if pattern.url_patterns:

--- a/django_js_utils/management/commands/js_urls.py
+++ b/django_js_utils/management/commands/js_urls.py
@@ -67,8 +67,10 @@ class Command(BaseCommand):
                     js_patterns[pattern.name] = "/" + full_url
             elif issubclass(pattern.__class__, RegexURLResolver):
                 if pattern.url_patterns:
-                    if pattern.url_patterns in URLS_JS_TO_EXPOSE:
-                        Command.handle_url_module(js_patterns, pattern.url_patterns, prefix=pattern.regex.pattern)
+                    if (isinstance(pattern.urlconf_name, types.ModuleType)
+                        and pattern.urlconf_name.__name__ not in URLS_JS_TO_EXPOSE):
+                        continue
+                    Command.handle_url_module(js_patterns, pattern.url_patterns, prefix=pattern.regex.pattern)
                 elif pattern.urlconf_name:
                     if pattern.urlconf_name in URLS_JS_TO_EXPOSE:
                         Command.handle_url_module(js_patterns, pattern.urlconf_name, prefix=pattern.regex.pattern)

--- a/django_js_utils/management/commands/js_urls.py
+++ b/django_js_utils/management/commands/js_urls.py
@@ -1,6 +1,7 @@
 import sys
 import re
 
+import types
 from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
 from django.core.management.base import BaseCommand
 from django.utils import simplejson
@@ -38,6 +39,9 @@ class Command(BaseCommand):
         if isinstance(module_name, basestring):
             __import__(module_name)
             root_urls = sys.modules[module_name]
+            patterns = root_urls.urlpatterns
+        elif isinstance(module_name, types.ModuleType):
+            root_urls = module_name
             patterns = root_urls.urlpatterns
         else:
             root_urls = module_name

--- a/django_js_utils/management/commands/js_urls.py
+++ b/django_js_utils/management/commands/js_urls.py
@@ -66,5 +66,9 @@ class Command(BaseCommand):
                             full_url = full_url.replace(el, "<>")#replace by a empty parameter name
                     js_patterns[pattern.name] = "/" + full_url
             elif issubclass(pattern.__class__, RegexURLResolver):
-                if pattern.urlconf_name and pattern.urlconf_name in URLS_JS_TO_EXPOSE:
-                    Command.handle_url_module(js_patterns, pattern.urlconf_name, prefix=pattern.regex.pattern)
+                if pattern.url_patterns:
+                    if pattern.url_patterns in URLS_JS_TO_EXPOSE:
+                        Command.handle_url_module(js_patterns, pattern.url_patterns, prefix=pattern.regex.pattern)
+                elif pattern.urlconf_name:
+                    if pattern.urlconf_name in URLS_JS_TO_EXPOSE:
+                        Command.handle_url_module(js_patterns, pattern.urlconf_name, prefix=pattern.regex.pattern)


### PR DESCRIPTION
Our patches make django-js-utils compatible with Django 1.4 and fix packaging so the JavaScript file ends up in the package when running setup.py sdist.

Looks like django-js-utils on PyPI is a version by @ljosa which removes the management command for generating a static mapping, and replaces it with a dynamic view.

Would it make sense to publish this version on PyPI e.g. as django-js-utils-static?
